### PR TITLE
[FEAT] 정답 건너뛰기 API 구현 (#32)

### DIFF
--- a/src/main/java/com/example/namoldak/controller/GameController.java
+++ b/src/main/java/com/example/namoldak/controller/GameController.java
@@ -1,0 +1,28 @@
+package com.example.namoldak.controller;
+
+import com.example.namoldak.service.GameService;
+import com.example.namoldak.util.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class GameController {
+
+    private final GameService gameService;
+
+    // 건너뛰기
+    @MessageMapping("/pub/game/{gameroomId}/skip")
+    public void gameSkip(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @DestinationVariable Long gameroomid) {
+
+        log.info("건너뛰기 - 게임 메세지 : {}, 게임방 아이디 : {}", userDetails.getMember(), gameroomid);
+        gameService.gameSkip(userDetails.getMember(), gameroomid);
+    }
+}

--- a/src/main/java/com/example/namoldak/domain/GameMessage.java
+++ b/src/main/java/com/example/namoldak/domain/GameMessage.java
@@ -9,17 +9,17 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class GameMessage <T>{
+public class GameMessage<T> {
+
     private String roomId;
     private String senderId;
     private String sender;
     private T content;
     private GameMessage.MessageType type;
 
-    //TODO 어떻게 하누
     public enum MessageType {
-        JOIN, READY, SPOTLIGHT, LEAVE, START, DRAW, ENDGAME, UPDATE, SWITCHING,
-        CONTINUE, RESULT,DRAWANDENDGAME, LIER, NLIER, UNREADY, ALLREADY, LIAR, TRUER, COMPLETE, ALLCOMPLETE, WAIT, REWARD, VOTE, ONEMOREROUND,
-        NEWOWNER, VICTORY, RESET
+        OWNER, ENTER, RULE, READY, START, KEYWORD,
+        FAIL, SKIP, SUCCESS, WINNER, ENDGAME,
+        LEAVE, NEWOWNER
     }
 }

--- a/src/main/java/com/example/namoldak/service/GameService.java
+++ b/src/main/java/com/example/namoldak/service/GameService.java
@@ -1,0 +1,33 @@
+package com.example.namoldak.service;
+
+import com.example.namoldak.domain.GameMessage;
+import com.example.namoldak.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class GameService {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    // 건너뛰기
+    @Transactional
+    public void gameSkip(Member member, Long gameroomid) {
+
+        // stomp로 메세지 전달
+        GameMessage gameMessage = new GameMessage();
+        gameMessage.setRoomId(Long.toString(gameroomid)); // 현재 방 id
+        gameMessage.setSenderId(String.valueOf(member.getId())); // 로그인한 유저의 id
+        gameMessage.setSender(member.getNickname()); // 로그인한 유저의 닉네임
+        gameMessage.setContent(gameMessage.getSender() + "님이 건너뛰기를 선택하셨습니다.");
+        gameMessage.setType(GameMessage.MessageType.SKIP);
+
+        // 방 안의 구독자 모두가 메세지 받음
+        messagingTemplate.convertAndSend("/sub/gameroom/" + gameroomid, gameMessage);
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/game-32 -> dev

### 변경사항
- GameMessage domain 내용 수정
- 정답 건너뛰기 API 추가