### PR TITLE
[FEAT] 카테고리별 게시글 조회 API 구현 (#83)

### DIFF
--- a/src/main/java/com/example/namoldak/controller/PostController.java
+++ b/src/main/java/com/example/namoldak/controller/PostController.java
@@ -10,12 +10,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 
 // 포스트 관련 CRUD 컨트롤러
 @RequiredArgsConstructor
-@RestController
+@Controller
 public class PostController {
     private final PostService postService;
 
@@ -27,9 +28,16 @@ public class PostController {
     }
 
     // 게시글 전체 불러오기
-    @GetMapping("posts/all")
-    public ResponseEntity<?> getAllPost(@PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+    @GetMapping("/posts/all")
+    public ResponseEntity<?> getAllPost(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseUtil.response(postService.getAllPost(pageable));
+    }
+
+    // 게시글 카테고리별 불러오기
+    @GetMapping("/posts/category") //posts/category?category=자유게시판
+    public ResponseEntity<?> getCategoryPost(@PageableDefault(page = 0, size = 10) Pageable pageable,
+                                             @RequestParam(required = false) String category) {
+        return ResponseUtil.response(postService.getCategoryPost(pageable, category));
     }
 
     // 게시글 수정

--- a/src/main/java/com/example/namoldak/dto/ResponseDto/PostResponseDto.java
+++ b/src/main/java/com/example/namoldak/dto/ResponseDto/PostResponseDto.java
@@ -17,8 +17,9 @@ public class PostResponseDto {
     private String content;                                                // 게시글 내용
     private String nickname;                                               // 작성자 닉네임
     private int cmtCnt;                                                    // 댓글 갯수
-//    private LocalDateTime createdAt;                                       // 작성 시간
-//    private LocalDateTime modifiedAt;                                      // 수정 시간
+    private String category;                                               // 카테고리
+//    private LocalDateTime createdAt;                                     // 작성 시간
+//    private LocalDateTime modifiedAt;                                    // 수정 시간
 
     public PostResponseDto(Post post){
         this.id           =     post.getId();
@@ -26,6 +27,7 @@ public class PostResponseDto {
         this.content      =     post.getContent();
         this.cmtCnt       =     post.getCommentList().size();
         this.nickname     =     post.getMember().getNickname();
+        this.category     =     post.getCategory();
 //        this.createdAt    =     post.getCreatedAt();
 //        this.modifiedAt   =     post.getModifiedAt();
     }

--- a/src/main/java/com/example/namoldak/dto/ResponseDto/PostResponseListDto.java
+++ b/src/main/java/com/example/namoldak/dto/ResponseDto/PostResponseListDto.java
@@ -1,0 +1,17 @@
+package com.example.namoldak.dto.ResponseDto;
+
+import com.example.namoldak.domain.Post;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostResponseListDto{
+    private int totalPage;
+    private List<PostResponseDto> postResponseDtoList;
+
+    public PostResponseListDto(int totalPage, List<PostResponseDto> postResponseDtoList) {
+        this.totalPage = (int) Math.ceil((double)totalPage / 10);
+        this.postResponseDtoList = postResponseDtoList;
+    }
+}

--- a/src/main/java/com/example/namoldak/repository/PostRepository.java
+++ b/src/main/java/com/example/namoldak/repository/PostRepository.java
@@ -1,7 +1,14 @@
 package com.example.namoldak.repository;
 
 import com.example.namoldak.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAllByCategoryOrderByCreatedAtDesc(Pageable pageable, String category);
+
+    List<Post> findAllByCategory(String category);
 }

--- a/src/main/java/com/example/namoldak/service/PostService.java
+++ b/src/main/java/com/example/namoldak/service/PostService.java
@@ -6,6 +6,7 @@ import com.example.namoldak.domain.Post;
 import com.example.namoldak.dto.RequestDto.PostRequestDto;
 import com.example.namoldak.dto.ResponseDto.CommentResponseDto;
 import com.example.namoldak.dto.ResponseDto.PostResponseDto;
+import com.example.namoldak.dto.ResponseDto.PostResponseListDto;
 import com.example.namoldak.dto.ResponseDto.PrivateResponseBody;
 import com.example.namoldak.repository.PostRepository;
 import com.example.namoldak.util.GlobalResponse.CustomException;
@@ -38,15 +39,32 @@ public class PostService {
 
     // 포스트 전체 조회
     @Transactional
-    public Page<PostResponseDto> getAllPost(Pageable pageable) {
+    public PostResponseListDto getAllPost(Pageable pageable) {
         Page<Post> postList = postRepository.findAll(pageable);
+        List<Post> posts = postRepository.findAll();
         List<PostResponseDto> postResponseDtoList = new ArrayList<>();
 
         for (Post post : postList) {
             postResponseDtoList.add(new PostResponseDto(post));
         }
-        final Page<PostResponseDto> page = new PageImpl<>(postResponseDtoList);
-        return page;
+        int totalPage = posts.size();
+//        final Page<PostResponseDto> page = new PageImpl<>(postResponseDtoList);
+        return new PostResponseListDto(totalPage, postResponseDtoList);
+    }
+
+    // 카테고리별 포스트 조회
+    public PostResponseListDto getCategoryPost(Pageable pageable, String category) {
+        Page<Post> postList = postRepository.findAllByCategoryOrderByCreatedAtDesc(pageable, category);
+        List<Post> posts = postRepository.findAllByCategory(category);
+        List<PostResponseDto> postResponseDtoList = new ArrayList<>();
+
+        for(Post post : postList) {
+            postResponseDtoList.add(new PostResponseDto(post));
+        }
+
+        int totalPage = posts.size();
+//        Page<PostResponseDto> page = new PageImpl<>(postResponseDtoList);
+        return new PostResponseListDto(totalPage, postResponseDtoList);
     }
 
     // 포스트 수정
@@ -75,5 +93,4 @@ public class PostService {
         }
         return new PrivateResponseBody<>(StatusCode.OK, "포스트 삭제가 완료되었습니다.");
     }
-
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/category-01-> develop

### 변경 사항
- 카테고리별 게시글 조회 API 구현
- page 자체가 아닌 list로 반환

### 테스트 결과
Postman 테스트 결과 이상 없습니다.