### PR TITLE
[FIX] 시그널링 Leave 처리 변경 #110

### DIFF
--- a/src/main/java/com/example/namoldak/repository/SessionRepository.java
+++ b/src/main/java/com/example/namoldak/repository/SessionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 // 기능 : 웹소켓에 필요한 세션 정보를 저장, 관리 (싱글톤)
 @Slf4j
@@ -14,7 +15,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class SessionRepository {
     private static SessionRepository sessionRepositoryRepo;
-    // 세션 저장 1) clientsInRoom : 방 Id를 key 값으로 하여 방마다 가지고 있는 Client들의 session Id 와 session 객체를 저장 
+    // 세션 저장 1) clientsInRoom : 방 Id를 key 값으로 하여 방마다 가지고 있는 Client들의 session Id 와 session 객체를 저장
     private final Map<Long, Map<String, WebSocketSession>> clientsInRoom = new HashMap<>();
     // 세션 저장 2) roomIdToSession : 참가자들 각각의 데이터로 session 객체를 key 값으로 하여 해당 객체가 어느방에 속해있는지를 저장
     private final Map<WebSocketSession, Long> roomIdToSession = new HashMap<>();
@@ -71,10 +72,17 @@ public class SessionRepository {
     public void addClient(Long roomId, WebSocketSession session) {
         clientsInRoom.get(roomId).put(session.getId(), session);
     }
-    
+
     // 방정보 모두 삭제 (방 폭파시 연계 작동)
     public void deleteAllclientsInRoom(Long roomId){
         clientsInRoom.remove(roomId);
+    }
+
+    public Map<WebSocketSession, Long> searchRooIdToSessionList(Long roomId){
+        return roomIdToSession.entrySet()
+                .stream()
+                .filter(entry ->  entry.getValue() == roomId)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public void saveRoomIdToSession(WebSocketSession session, Long roomId) {


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
fix/110 -> dev

### 변경 사항
- 메세지 Leave로 소켓 연결 끊는 처리를 하는 방식이 아닌, 프론트에서 웹소켓 연결을 끊는 메소드를 사용해 백엔드의 afterConnectionClosed 메소드를 실행시키는 방식으로 교체

### 테스트 결과
프론트(로컬)와의 테스트 결과 이상 없습니다.