### PR TITLE
[REFACTOR] Refresh Token header에 전달, 카카오 client_id 값 암호화 #269

### DIFF
--- a/src/main/java/com/example/namoldak/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/namoldak/config/WebSecurityConfig.java
@@ -75,6 +75,7 @@ public class WebSecurityConfig {
         config.addAllowedOrigin("https://d3j37rx7mer6cg.cloudfront.net");
         // addExposedHeader : 프론트에서 헤더의 해당 값에 접근할 수 있게 허락해주는 옵션
         config.addExposedHeader(JwtUtil.ACCESS_TOKEN);
+        config.addExposedHeader(JwtUtil.REFRESH_TOKEN);
         config.addExposedHeader(JwtUtil.KAKAO_TOKEN);
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");

--- a/src/main/java/com/example/namoldak/controller/MemberController.java
+++ b/src/main/java/com/example/namoldak/controller/MemberController.java
@@ -98,7 +98,7 @@ public class MemberController {
     }
 
     // 토큰 재발행
-    @PostMapping("/auth/issue/token")
+    @GetMapping("/auth/issue/token")
     public ResponseDto<String> issuedToken(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response){
         return memberService.issuedToken(userDetails.getMember().getEmail(), response);
     }

--- a/src/main/java/com/example/namoldak/domain/RefreshToken.java
+++ b/src/main/java/com/example/namoldak/domain/RefreshToken.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.core.RedisHash;
 @Getter
 @Setter
 @NoArgsConstructor
-@RedisHash(value = "refreshToken", timeToLive = 7 * 24 * 60 * 60L ) // 초단위 = 7일
+@RedisHash(value = "refreshToken", timeToLive = 7 * 24 * 60 * 60L ) //  = 7일
 public class RefreshToken {
     @Id
     private String email;

--- a/src/main/java/com/example/namoldak/service/KakaoService.java
+++ b/src/main/java/com/example/namoldak/service/KakaoService.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -42,6 +43,9 @@ public class KakaoService {
     private final MemberCommand memberCommand;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
+
+    @Value("${kakao.oauth2.client.id}")
+    String client_id;
 
     public String kakaoLogin(String code, HttpServletResponse response) {
         // 1. "인가 코드"로 "액세스 토큰" 요청
@@ -81,7 +85,7 @@ public class KakaoService {
         // HTTP Body 생성
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
-        body.add("client_id", "8e8f2cd2d31d1ee1c2d676f16d9430a0"); // REST API키
+        body.add("client_id", client_id); // REST API키
         body.add("redirect_uri", "https://namoldak.com/login");
         body.add("code", code);
 

--- a/src/main/java/com/example/namoldak/service/MemberService.java
+++ b/src/main/java/com/example/namoldak/service/MemberService.java
@@ -137,7 +137,7 @@ public class MemberService {
 
     private void setHeader(HttpServletResponse response, TokenDto tokenDto) {
         response.addHeader(JwtUtil.ACCESS_TOKEN, tokenDto.getAccessToken());
-//        response.addHeader(JwtUtil.REFRESH_TOKEN, tokenDto.getRefreshToken());
+        response.addHeader(JwtUtil.REFRESH_TOKEN, tokenDto.getRefreshToken());
     }
 
     // 로그아웃

--- a/src/main/java/com/example/namoldak/util/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/namoldak/util/jwt/JwtAuthFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -33,7 +34,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 return;
             }
             setAuthentication(jwtUtil.getUserInfoFromToken(accessToken));
-
         } else if (refreshToken != null) {
             if (!jwtUtil.refreshTokenValidation(refreshToken)) {
                 jwtExceptionHandler(response, "RefreshToken Expired", HttpStatus.UNAUTHORIZED);

--- a/src/main/java/com/example/namoldak/util/jwt/JwtUtil.java
+++ b/src/main/java/com/example/namoldak/util/jwt/JwtUtil.java
@@ -52,7 +52,7 @@ public class JwtUtil {
 
     // 토큰 생성
     public TokenDto createAllToken(String email) {
-        return new TokenDto(createToken(email, "Access"));
+        return new TokenDto(createToken(email, "Access"), createToken(email, "Refresh"));
     }
 
     // 토큰 생성

--- a/src/main/java/com/example/namoldak/util/jwt/TokenDto.java
+++ b/src/main/java/com/example/namoldak/util/jwt/TokenDto.java
@@ -7,8 +7,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TokenDto {
     private String accessToken;
+    private String refreshToken;
 
-    public TokenDto(String accessToken) {
+    public TokenDto(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/refresh-269 -> dev

### 변경 사항
- Refresh Token header에 전달
- 카카오 client_id 값 암호화

### 테스트 결과
Postman 테스트 OK